### PR TITLE
updated CI integration to reflect new flake-pure functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ params
 proof
 verifying_key
 result-bin
+result
 
 # generated from tests
 circuit.dot

--- a/ci.nix
+++ b/ci.nix
@@ -1,3 +1,0 @@
-if builtins?getFlake
-then (builtins.getFlake (toString ./.)).ciNix
-else (import ./flake-compat.nix).defaultNix.ciNix

--- a/flake-compat.nix
+++ b/flake-compat.nix
@@ -1,9 +1,0 @@
-let
-  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-  inherit (lock.nodes.flake-compat.locked) owner repo rev narHash;
-  flake-compat = builtins.fetchTarball {
-    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
-    sha256 = narHash;
-  };
-in
-import flake-compat { src = ./.; }

--- a/flake.lock
+++ b/flake.lock
@@ -20,37 +20,6 @@
         "type": "github"
       }
     },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat-ci": {
-      "locked": {
-        "lastModified": 1641672839,
-        "narHash": "sha256-Bdwv+DKeEMlRNPDpZxSz0sSrqQBvdKO5fZ8LmvrgCOU=",
-        "owner": "hercules-ci",
-        "repo": "flake-compat-ci",
-        "rev": "e832114bc18376c0f3fa13c19bf5ff253cc6570a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-compat-ci",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "locked": {
         "lastModified": 1638122382,
@@ -147,8 +116,6 @@
     "root": {
       "inputs": {
         "cargo2nix": "cargo2nix",
-        "flake-compat": "flake-compat",
-        "flake-compat-ci": "flake-compat-ci",
         "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_2",
         "rust-overlay": "rust-overlay_2"

--- a/flake.nix
+++ b/flake.nix
@@ -7,14 +7,9 @@
       nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
       rust-overlay.url = "github:oxalica/rust-overlay";
       flake-utils.url = "github:numtide/flake-utils";
-      flake-compat-ci.url = "github:hercules-ci/flake-compat-ci";
-      flake-compat = {
-        url = "github:edolstra/flake-compat";
-        flake = false;
-      };
     };
 
-  outputs = { self, cargo2nix, flake-utils, nixpkgs, rust-overlay, flake-compat, flake-compat-ci, ... }:
+  outputs = { self, cargo2nix, flake-utils, nixpkgs, rust-overlay, ... }:
     with builtins;
     flake-utils.lib.eachDefaultSystem
       (system:
@@ -120,10 +115,7 @@
                 '';
             };
 
-          ciNix = flake-compat-ci.lib.recurseIntoFlakeWith {
-            flake = self;
-            systems = [ "x86_64-linux" ];
-          };
+            herculesCI.ciSystems = [ "x86_64-linux" ];
         }
       );
 }


### PR DESCRIPTION
As our instance of Hercules has been updated, we no longer require the ci-compat shim to build using flakes.
Given native support of our functional pipeline, I am removing the ci-compat throughout our repositories.