### PR TITLE
Out matches instruction + in_trace + time: Fixed + Refactor

### DIFF
--- a/src/assign.rs
+++ b/src/assign.rs
@@ -1,7 +1,7 @@
 use halo2_proofs::{
     arithmetic::FieldExt,
-    circuit::{AssignedCell, Region, Value},
-    plonk::{Advice, Column, ConstraintSystem, Fixed, Instance},
+    circuit::{AssignedCell, Region, Table, Value},
+    plonk::{Advice, Column, ConstraintSystem, Fixed, Instance, TableColumn},
 };
 
 pub trait NewColumn<C: Copy> {
@@ -92,6 +92,19 @@ impl<'r, F: FieldExt>
     ) -> Result<Self::AssignedRef, halo2_proofs::plonk::Error> {
         self.0
             .assign_advice(|| "", column, self.1, &mut || Value::known(f))
+    }
+}
+
+/// An impl of push_cell for `(Region, offset)`.
+impl<'r, F: FieldExt> PushRow<F, TableColumn> for (&mut Table<'r, F>, usize) {
+    type AssignedRef = ();
+    fn push_cell(
+        &mut self,
+        column: TableColumn,
+        f: F,
+    ) -> Result<Self::AssignedRef, halo2_proofs::plonk::Error> {
+        self.0
+            .assign_cell(|| "", column, self.1, &mut || Value::known(f))
     }
 }
 

--- a/src/circuits/tables/aux.rs
+++ b/src/circuits/tables/aux.rs
@@ -40,10 +40,10 @@ impl<const REG_COUNT: usize, C: Copy> ExeRow<REG_COUNT, C> {
 
 #[derive(Debug, Clone, Copy)]
 pub struct TempVarSelectors<const REG_COUNT: usize, C: Copy> {
-    pub a: SelectiorsA<REG_COUNT, C>,
-    pub b: SelectiorsB<REG_COUNT, C>,
-    pub c: SelectiorsC<REG_COUNT, C>,
-    pub d: SelectiorsD<REG_COUNT, C>,
+    pub a: SelectorsA<REG_COUNT, C>,
+    pub b: SelectorsB<REG_COUNT, C>,
+    pub c: SelectorsC<REG_COUNT, C>,
+    pub d: SelectorsD<REG_COUNT, C>,
     pub out: Out<C>,
     pub ch: UnChangedSelectors<REG_COUNT, C>,
 }
@@ -54,10 +54,10 @@ impl<const REG_COUNT: usize, C: Copy> TempVarSelectors<REG_COUNT, C> {
         M: NewColumn<C>,
     {
         TempVarSelectors {
-            a: SelectiorsA::new_columns::<F, M>(meta),
-            b: SelectiorsB::new_columns::<F, M>(meta),
-            c: SelectiorsC::new_columns::<F, M>(meta),
-            d: SelectiorsD::new_columns::<F, M>(meta),
+            a: SelectorsA::new_columns::<F, M>(meta),
+            b: SelectorsB::new_columns::<F, M>(meta),
+            c: SelectorsC::new_columns::<F, M>(meta),
+            d: SelectorsD::new_columns::<F, M>(meta),
             out: Out::new(|| meta.new_column()),
             ch: UnChangedSelectors::new(|| meta.new_column()),
         }
@@ -582,10 +582,10 @@ pub enum SelectionA {
     NonDet,
 }
 
-/// Use `SelectiorsA::new_*` to construct correct selectors.
+/// Use `SelectorsA::new_*` to construct correct selectors.
 /// Fields ending with `next` refer to the next row (`t+1).
 #[derive(Debug, Clone, Copy)]
-pub struct SelectiorsA<const REG_COUNT: usize, C: Copy> {
+pub struct SelectorsA<const REG_COUNT: usize, C: Copy> {
     pub pc_next: C,
 
     pub reg: Registers<REG_COUNT, C>,
@@ -598,9 +598,9 @@ pub struct SelectiorsA<const REG_COUNT: usize, C: Copy> {
     pub non_det: C,
 }
 
-impl<const REG_COUNT: usize> From<SelectionA> for SelectiorsA<REG_COUNT, bool> {
+impl<const REG_COUNT: usize> From<SelectionA> for SelectorsA<REG_COUNT, bool> {
     fn from(s: SelectionA) -> Self {
-        let mut r = SelectiorsA {
+        let mut r = SelectorsA {
             pc_next: false,
             reg: Registers([false; REG_COUNT]),
             reg_next: Registers([false; REG_COUNT]),
@@ -621,12 +621,12 @@ impl<const REG_COUNT: usize> From<SelectionA> for SelectiorsA<REG_COUNT, bool> {
     }
 }
 
-impl<const REG_COUNT: usize, C: Copy> SelectiorsA<REG_COUNT, C> {
+impl<const REG_COUNT: usize, C: Copy> SelectorsA<REG_COUNT, C> {
     fn new_columns<F: FieldExt, M>(meta: &mut M) -> Self
     where
         M: NewColumn<C>,
     {
-        SelectiorsA {
+        SelectorsA {
             pc_next: meta.new_column(),
             // Do not replace with `[meta.new_column(); REG_COUNT]` it's not equivalent.
             reg: [0; REG_COUNT].map(|_| meta.new_column()).into(),
@@ -638,11 +638,11 @@ impl<const REG_COUNT: usize, C: Copy> SelectiorsA<REG_COUNT, C> {
     }
 }
 
-impl<const REG_COUNT: usize, C: Copy> SelectiorsA<REG_COUNT, C> {
+impl<const REG_COUNT: usize, C: Copy> SelectorsA<REG_COUNT, C> {
     fn push_cells<F: FieldExt, R: PushRow<F, C>>(
         self,
         region: &mut R,
-        vals: SelectiorsA<REG_COUNT, bool>,
+        vals: SelectorsA<REG_COUNT, bool>,
     ) {
         let Self {
             pc_next,
@@ -686,10 +686,10 @@ pub enum SelectionB {
     MaxWord,
 }
 
-/// Use `SelectiorsA::new_*` to construct correct selectors.
+/// Use `SelectorsA::new_*` to construct correct selectors.
 /// Fields ending with `next` refer to the next row (`t+1).
 #[derive(Debug, Clone, Copy)]
-pub struct SelectiorsB<const REG_COUNT: usize, C: Copy> {
+pub struct SelectorsB<const REG_COUNT: usize, C: Copy> {
     pub pc: C,
     pub pc_next: C,
 
@@ -706,12 +706,12 @@ pub struct SelectiorsB<const REG_COUNT: usize, C: Copy> {
     pub max_word: C,
 }
 
-impl<const REG_COUNT: usize, C: Copy> SelectiorsB<REG_COUNT, C> {
+impl<const REG_COUNT: usize, C: Copy> SelectorsB<REG_COUNT, C> {
     fn new_columns<F: FieldExt, M>(meta: &mut M) -> Self
     where
         M: NewColumn<C>,
     {
-        SelectiorsB {
+        SelectorsB {
             pc: meta.new_column(),
             pc_next: meta.new_column(),
             pc_plus_one: meta.new_column(),
@@ -725,9 +725,9 @@ impl<const REG_COUNT: usize, C: Copy> SelectiorsB<REG_COUNT, C> {
     }
 }
 
-impl<const REG_COUNT: usize> From<SelectionB> for SelectiorsB<REG_COUNT, bool> {
+impl<const REG_COUNT: usize> From<SelectionB> for SelectorsB<REG_COUNT, bool> {
     fn from(s: SelectionB) -> Self {
-        let mut r = SelectiorsB {
+        let mut r = SelectorsB {
             pc: false,
             pc_next: false,
             pc_plus_one: false,
@@ -752,11 +752,11 @@ impl<const REG_COUNT: usize> From<SelectionB> for SelectiorsB<REG_COUNT, bool> {
     }
 }
 
-impl<const REG_COUNT: usize, C: Copy> SelectiorsB<REG_COUNT, C> {
+impl<const REG_COUNT: usize, C: Copy> SelectorsB<REG_COUNT, C> {
     fn push_cells<F: FieldExt, R: PushRow<F, C>>(
         self,
         region: &mut R,
-        vals: SelectiorsB<REG_COUNT, bool>,
+        vals: SelectorsB<REG_COUNT, bool>,
     ) {
         let Self {
             pc,
@@ -801,10 +801,10 @@ pub enum SelectionC {
     Zero,
 }
 
-/// Use `SelectiorsA::new_*` to construct correct selectors.
+/// Use `SelectorsA::new_*` to construct correct selectors.
 /// Fields ending with `next` refer to the next row (`t+1).
 #[derive(Debug, Clone, Copy)]
-pub struct SelectiorsC<const REG_COUNT: usize, C: Copy> {
+pub struct SelectorsC<const REG_COUNT: usize, C: Copy> {
     pub reg: Registers<REG_COUNT, C>,
     pub reg_next: Registers<REG_COUNT, C>,
 
@@ -816,12 +816,12 @@ pub struct SelectiorsC<const REG_COUNT: usize, C: Copy> {
     pub zero: C,
 }
 
-impl<const REG_COUNT: usize, C: Copy> SelectiorsC<REG_COUNT, C> {
+impl<const REG_COUNT: usize, C: Copy> SelectorsC<REG_COUNT, C> {
     fn new_columns<F: FieldExt, M>(meta: &mut M) -> Self
     where
         M: NewColumn<C>,
     {
-        SelectiorsC {
+        SelectorsC {
             // Do not replace with `[meta.new_column(); REG_COUNT]` it's not equivalent.
             reg: Registers([0; REG_COUNT].map(|_| meta.new_column())),
             reg_next: Registers([0; REG_COUNT].map(|_| meta.new_column())),
@@ -832,9 +832,9 @@ impl<const REG_COUNT: usize, C: Copy> SelectiorsC<REG_COUNT, C> {
     }
 }
 
-impl<const REG_COUNT: usize> From<SelectionC> for SelectiorsC<REG_COUNT, bool> {
+impl<const REG_COUNT: usize> From<SelectionC> for SelectorsC<REG_COUNT, bool> {
     fn from(s: SelectionC) -> Self {
-        let mut r = SelectiorsC {
+        let mut r = SelectorsC {
             reg: Registers([false; REG_COUNT]),
             reg_next: Registers([false; REG_COUNT]),
             a: false,
@@ -853,11 +853,11 @@ impl<const REG_COUNT: usize> From<SelectionC> for SelectiorsC<REG_COUNT, bool> {
     }
 }
 
-impl<const REG_COUNT: usize, C: Copy> SelectiorsC<REG_COUNT, C> {
+impl<const REG_COUNT: usize, C: Copy> SelectorsC<REG_COUNT, C> {
     fn push_cells<F: FieldExt, R: PushRow<F, C>>(
         self,
         region: &mut R,
-        vals: SelectiorsC<REG_COUNT, bool>,
+        vals: SelectorsC<REG_COUNT, bool>,
     ) {
         let Self {
             reg,
@@ -901,10 +901,10 @@ pub enum SelectionD {
     Unset,
 }
 
-/// Use `SelectiorsD::new_*` and From<SelectionD> to construct correct selectors.
+/// Use `SelectorsD::new_*` and From<SelectionD> to construct correct selectors.
 /// Fields ending with `next` refer to the next row (`t+1).
 #[derive(Debug, Clone, Copy)]
-pub struct SelectiorsD<const REG_COUNT: usize, C: Copy> {
+pub struct SelectorsD<const REG_COUNT: usize, C: Copy> {
     pub pc: C,
 
     pub reg: Registers<REG_COUNT, C>,
@@ -919,12 +919,12 @@ pub struct SelectiorsD<const REG_COUNT: usize, C: Copy> {
     pub one: C,
 }
 
-impl<const REG_COUNT: usize, C: Copy> SelectiorsD<REG_COUNT, C> {
+impl<const REG_COUNT: usize, C: Copy> SelectorsD<REG_COUNT, C> {
     fn new_columns<F: FieldExt, M>(meta: &mut M) -> Self
     where
         M: NewColumn<C>,
     {
-        SelectiorsD {
+        SelectorsD {
             // Do not replace with `[meta.new_column(); REG_COUNT]` it's not equivalent.
             pc: meta.new_column(),
 
@@ -938,9 +938,9 @@ impl<const REG_COUNT: usize, C: Copy> SelectiorsD<REG_COUNT, C> {
     }
 }
 
-impl<const REG_COUNT: usize> From<SelectionD> for SelectiorsD<REG_COUNT, bool> {
+impl<const REG_COUNT: usize> From<SelectionD> for SelectorsD<REG_COUNT, bool> {
     fn from(s: SelectionD) -> Self {
-        let mut r = SelectiorsD {
+        let mut r = SelectorsD {
             pc: false,
             reg: Registers([false; REG_COUNT]),
             reg_next: Registers([false; REG_COUNT]),
@@ -967,11 +967,11 @@ impl<const REG_COUNT: usize> From<SelectionD> for SelectiorsD<REG_COUNT, bool> {
     }
 }
 
-impl<const REG_COUNT: usize, C: Copy> SelectiorsD<REG_COUNT, C> {
+impl<const REG_COUNT: usize, C: Copy> SelectorsD<REG_COUNT, C> {
     fn push_cells<F: FieldExt, R: PushRow<F, C>>(
         self,
         region: &mut R,
-        vals: SelectiorsD<REG_COUNT, bool>,
+        vals: SelectorsD<REG_COUNT, bool>,
     ) {
         let Self {
             pc,

--- a/src/circuits/tables/aux/out.rs
+++ b/src/circuits/tables/aux/out.rs
@@ -64,6 +64,24 @@ impl<T> Out<T> {
             flag4: new_fn(),
         }
     }
+
+    pub fn map<B>(self, mut f: impl FnMut(T) -> B) -> Out<B> {
+        Out {
+            and: f(self.and),
+            xor: f(self.xor),
+            or: f(self.or),
+            sum: f(self.sum),
+            prod: f(self.prod),
+            ssum: f(self.ssum),
+            sprod: f(self.sprod),
+            mod_: f(self.mod_),
+            shift: f(self.shift),
+            flag1: f(self.flag1),
+            flag2: f(self.flag2),
+            flag3: f(self.flag3),
+            flag4: f(self.flag4),
+        }
+    }
 }
 
 impl<C> Out<C> {

--- a/src/circuits/tables/aux/out.rs
+++ b/src/circuits/tables/aux/out.rs
@@ -1,0 +1,337 @@
+use halo2_proofs::{arithmetic::FieldExt, plonk};
+
+use crate::{
+    assign::PushRow,
+    trace::{
+        Add, And, Answer, CJmp, CMov, Cmpa, Cmpae, Cmpe, Cmpg, Cmpge, CnJmp, Jmp,
+        LoadW, Mov, Mull, Not, Or, SMulh, Shl, Shr, StoreW, Sub, UDiv, UMod, UMulh,
+        Xor,
+    },
+};
+
+pub trait OutPut {
+    const OUT: Out<bool>;
+}
+
+/// This corresponds to `s_out` in the paper (page 24).
+#[derive(Debug, Clone, Copy)]
+pub struct Out<T> {
+    /// logical
+    pub and: T,
+    pub xor: T,
+    pub or: T,
+
+    /// arithmetic
+    pub sum: T,
+    pub ssum: T,
+    pub prod: T,
+    pub sprod: T,
+    pub mod_: T,
+
+    pub shift: T,
+
+    pub flag1: T,
+    pub flag2: T,
+    pub flag3: T,
+    pub flag4: T,
+}
+
+// serves as default, except it's private.
+const EMPTY_OUT: Out<bool> = Out {
+    and: false,
+    xor: false,
+    or: false,
+    sum: false,
+    prod: false,
+    ssum: false,
+    sprod: false,
+    mod_: false,
+    shift: false,
+    flag1: false,
+    flag2: false,
+    flag3: false,
+    flag4: false,
+};
+
+impl<T> Out<T> {
+    pub fn new(mut new_fn: impl FnMut() -> T) -> Out<T> {
+        Out {
+            and: new_fn(),
+            xor: new_fn(),
+            or: new_fn(),
+            sum: new_fn(),
+            prod: new_fn(),
+            ssum: new_fn(),
+            sprod: new_fn(),
+            mod_: new_fn(),
+            shift: new_fn(),
+            flag1: new_fn(),
+            flag2: new_fn(),
+            flag3: new_fn(),
+            flag4: new_fn(),
+        }
+    }
+}
+
+impl<C> Out<C> {
+    pub fn push_cells<F: FieldExt, R: PushRow<F, C>>(
+        self,
+        region: &mut R,
+        vals: Out<bool>,
+    ) -> Result<(), plonk::Error> {
+        let Self {
+            and,
+            xor,
+            or,
+            sum,
+            prod,
+            ssum,
+            sprod,
+            mod_,
+            shift,
+            flag1,
+            flag2,
+            flag3,
+            flag4,
+        } = self;
+
+        region.push_cell(and, vals.and.into())?;
+        region.push_cell(xor, vals.xor.into())?;
+        region.push_cell(or, vals.or.into())?;
+        region.push_cell(sum, vals.sum.into())?;
+        region.push_cell(prod, vals.prod.into())?;
+        region.push_cell(ssum, vals.ssum.into())?;
+        region.push_cell(sprod, vals.sprod.into())?;
+        region.push_cell(mod_, vals.mod_.into())?;
+        region.push_cell(shift, vals.shift.into())?;
+        region.push_cell(flag1, vals.flag1.into())?;
+        region.push_cell(flag2, vals.flag2.into())?;
+        region.push_cell(flag3, vals.flag3.into())?;
+        region.push_cell(flag4, vals.flag4.into())?;
+
+        Ok(())
+    }
+}
+
+impl<T> Out<T> {
+    pub fn convert<B: From<T>>(self) -> Out<B> {
+        Out {
+            and: self.and.into(),
+            xor: self.xor.into(),
+            or: self.or.into(),
+            sum: self.sum.into(),
+            prod: self.prod.into(),
+            ssum: self.ssum.into(),
+            sprod: self.sprod.into(),
+            mod_: self.mod_.into(),
+            shift: self.shift.into(),
+            flag1: self.flag1.into(),
+            flag2: self.flag2.into(),
+            flag3: self.flag3.into(),
+            flag4: self.flag4.into(),
+        }
+    }
+}
+
+impl OutPut for And {
+    const OUT: Out<bool> = Out {
+        and: true,
+        flag1: true,
+        flag2: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for Or {
+    const OUT: Out<bool> = Out {
+        or: true,
+        flag1: true,
+        flag2: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for Xor {
+    const OUT: Out<bool> = Out {
+        xor: true,
+        flag1: true,
+        flag2: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for Not {
+    const OUT: Out<bool> = Out {
+        xor: true,
+        flag1: true,
+        flag2: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for Add {
+    const OUT: Out<bool> = Out {
+        sum: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for Sub {
+    const OUT: Out<bool> = Out {
+        sum: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for Mull {
+    const OUT: Out<bool> = Out {
+        prod: true,
+        flag1: true,
+        flag2: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for UMulh {
+    const OUT: Out<bool> = Out {
+        prod: true,
+        flag1: true,
+        flag2: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for SMulh {
+    const OUT: Out<bool> = Out {
+        sprod: true,
+        flag1: true,
+        flag2: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for UDiv {
+    const OUT: Out<bool> = Out {
+        mod_: true,
+        flag1: true,
+        flag2: true,
+        flag3: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for UMod {
+    const OUT: Out<bool> = Out {
+        mod_: true,
+        flag1: true,
+        flag2: true,
+        flag3: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for Shl {
+    const OUT: Out<bool> = Out {
+        shift: true,
+        flag4: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for Shr {
+    const OUT: Out<bool> = Out {
+        shift: true,
+        flag4: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for Cmpe {
+    const OUT: Out<bool> = Out {
+        xor: true,
+        flag1: true,
+        flag2: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for Cmpa {
+    const OUT: Out<bool> = Out {
+        sum: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for Cmpae {
+    const OUT: Out<bool> = Out {
+        sum: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for Cmpg {
+    const OUT: Out<bool> = Out {
+        ssum: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for Cmpge {
+    const OUT: Out<bool> = Out {
+        ssum: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for Mov {
+    const OUT: Out<bool> = Out {
+        xor: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for CMov {
+    const OUT: Out<bool> = Out {
+        mod_: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for Jmp {
+    const OUT: Out<bool> = Out {
+        xor: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for CJmp {
+    const OUT: Out<bool> = Out {
+        mod_: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for CnJmp {
+    const OUT: Out<bool> = Out {
+        mod_: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for LoadW {
+    const OUT: Out<bool> = Out {
+        // FIXME
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for StoreW {
+    const OUT: Out<bool> = Out {
+        xor: true,
+        ..EMPTY_OUT
+    };
+}
+
+impl OutPut for Answer {
+    const OUT: Out<bool> = EMPTY_OUT;
+}

--- a/src/circuits/tables/aux/out.rs
+++ b/src/circuits/tables/aux/out.rs
@@ -1,13 +1,6 @@
 use halo2_proofs::{arithmetic::FieldExt, plonk};
 
-use crate::{
-    assign::PushRow,
-    trace::{
-        Add, And, Answer, CJmp, CMov, Cmpa, Cmpae, Cmpe, Cmpg, Cmpge, CnJmp, Jmp,
-        LoadW, Mov, Mull, Not, Or, SMulh, Shl, Shr, StoreW, Sub, UDiv, UMod, UMulh,
-        Xor,
-    },
-};
+use crate::{assign::PushRow, instructions::*};
 
 pub trait OutPut {
     const OUT: Out<bool>;
@@ -133,7 +126,7 @@ impl<T> Out<T> {
     }
 }
 
-impl OutPut for And {
+impl<R, A> OutPut for And<R, A> {
     const OUT: Out<bool> = Out {
         and: true,
         flag1: true,
@@ -142,7 +135,7 @@ impl OutPut for And {
     };
 }
 
-impl OutPut for Or {
+impl<R, A> OutPut for Or<R, A> {
     const OUT: Out<bool> = Out {
         or: true,
         flag1: true,
@@ -151,7 +144,7 @@ impl OutPut for Or {
     };
 }
 
-impl OutPut for Xor {
+impl<R, A> OutPut for Xor<R, A> {
     const OUT: Out<bool> = Out {
         xor: true,
         flag1: true,
@@ -160,7 +153,7 @@ impl OutPut for Xor {
     };
 }
 
-impl OutPut for Not {
+impl<R, A> OutPut for Not<R, A> {
     const OUT: Out<bool> = Out {
         xor: true,
         flag1: true,
@@ -169,21 +162,21 @@ impl OutPut for Not {
     };
 }
 
-impl OutPut for Add {
+impl<R, A> OutPut for Add<R, A> {
     const OUT: Out<bool> = Out {
         sum: true,
         ..EMPTY_OUT
     };
 }
 
-impl OutPut for Sub {
+impl<R, A> OutPut for Sub<R, A> {
     const OUT: Out<bool> = Out {
         sum: true,
         ..EMPTY_OUT
     };
 }
 
-impl OutPut for Mull {
+impl<R, A> OutPut for Mull<R, A> {
     const OUT: Out<bool> = Out {
         prod: true,
         flag1: true,
@@ -192,7 +185,7 @@ impl OutPut for Mull {
     };
 }
 
-impl OutPut for UMulh {
+impl<R, A> OutPut for UMulh<R, A> {
     const OUT: Out<bool> = Out {
         prod: true,
         flag1: true,
@@ -201,7 +194,7 @@ impl OutPut for UMulh {
     };
 }
 
-impl OutPut for SMulh {
+impl<R, A> OutPut for SMulh<R, A> {
     const OUT: Out<bool> = Out {
         sprod: true,
         flag1: true,
@@ -210,7 +203,7 @@ impl OutPut for SMulh {
     };
 }
 
-impl OutPut for UDiv {
+impl<R, A> OutPut for UDiv<R, A> {
     const OUT: Out<bool> = Out {
         mod_: true,
         flag1: true,
@@ -220,7 +213,7 @@ impl OutPut for UDiv {
     };
 }
 
-impl OutPut for UMod {
+impl<R, A> OutPut for UMod<R, A> {
     const OUT: Out<bool> = Out {
         mod_: true,
         flag1: true,
@@ -230,7 +223,7 @@ impl OutPut for UMod {
     };
 }
 
-impl OutPut for Shl {
+impl<R, A> OutPut for Shl<R, A> {
     const OUT: Out<bool> = Out {
         shift: true,
         flag4: true,
@@ -238,7 +231,7 @@ impl OutPut for Shl {
     };
 }
 
-impl OutPut for Shr {
+impl<R, A> OutPut for Shr<R, A> {
     const OUT: Out<bool> = Out {
         shift: true,
         flag4: true,
@@ -246,7 +239,7 @@ impl OutPut for Shr {
     };
 }
 
-impl OutPut for Cmpe {
+impl<R, A> OutPut for Cmpe<R, A> {
     const OUT: Out<bool> = Out {
         xor: true,
         flag1: true,
@@ -255,83 +248,83 @@ impl OutPut for Cmpe {
     };
 }
 
-impl OutPut for Cmpa {
+impl<R, A> OutPut for Cmpa<R, A> {
     const OUT: Out<bool> = Out {
         sum: true,
         ..EMPTY_OUT
     };
 }
 
-impl OutPut for Cmpae {
+impl<R, A> OutPut for Cmpae<R, A> {
     const OUT: Out<bool> = Out {
         sum: true,
         ..EMPTY_OUT
     };
 }
 
-impl OutPut for Cmpg {
+impl<R, A> OutPut for Cmpg<R, A> {
     const OUT: Out<bool> = Out {
         ssum: true,
         ..EMPTY_OUT
     };
 }
 
-impl OutPut for Cmpge {
+impl<R, A> OutPut for Cmpge<R, A> {
     const OUT: Out<bool> = Out {
         ssum: true,
         ..EMPTY_OUT
     };
 }
 
-impl OutPut for Mov {
+impl<R, A> OutPut for Mov<R, A> {
     const OUT: Out<bool> = Out {
         xor: true,
         ..EMPTY_OUT
     };
 }
 
-impl OutPut for CMov {
+impl<R, A> OutPut for CMov<R, A> {
     const OUT: Out<bool> = Out {
         mod_: true,
         ..EMPTY_OUT
     };
 }
 
-impl OutPut for Jmp {
+impl<A> OutPut for Jmp<A> {
     const OUT: Out<bool> = Out {
         xor: true,
         ..EMPTY_OUT
     };
 }
 
-impl OutPut for CJmp {
+impl<A> OutPut for CJmp<A> {
     const OUT: Out<bool> = Out {
         mod_: true,
         ..EMPTY_OUT
     };
 }
 
-impl OutPut for CnJmp {
+impl<A> OutPut for CnJmp<A> {
     const OUT: Out<bool> = Out {
         mod_: true,
         ..EMPTY_OUT
     };
 }
 
-impl OutPut for LoadW {
+impl<R, A> OutPut for LoadW<R, A> {
     const OUT: Out<bool> = Out {
         // FIXME
         ..EMPTY_OUT
     };
 }
 
-impl OutPut for StoreW {
+impl<R, A> OutPut for StoreW<R, A> {
     const OUT: Out<bool> = Out {
         xor: true,
         ..EMPTY_OUT
     };
 }
 
-impl OutPut for Answer {
+impl<A> OutPut for Answer<A> {
     const OUT: Out<bool> = EMPTY_OUT;
 }

--- a/src/circuits/tables/aux/out_table.rs
+++ b/src/circuits/tables/aux/out_table.rs
@@ -1,0 +1,8 @@
+use halo2_proofs::plonk::TableColumn;
+
+use super::out::Out;
+
+pub struct OutTable {
+    opcode: TableColumn,
+    out: Out<TableColumn>,
+}

--- a/src/circuits/tables/aux/out_table.rs
+++ b/src/circuits/tables/aux/out_table.rs
@@ -8,8 +8,9 @@ use halo2_proofs::{
 };
 
 use super::out::{Out, OutPut};
-use crate::instructions::{opcode::OpCode, *};
+use crate::instructions::{opcode::OpCode, unit::*};
 
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 pub struct CorrectOutConfig {
     opcode: Column<Advice>,
@@ -24,15 +25,15 @@ impl CorrectOutConfig {
         opcode: Column<Advice>,
         out: Out<Column<Advice>>,
         // A advice selector denoting if a line of Exe is part of the trace.
-        s_correct_out: Column<Advice>,
+        s_in_trace: Column<Advice>,
         // A complex selector denoting the extent in rows of the table to decompose.
         s_table: Selector,
+        out_table: OutTable,
     ) -> Self {
-        let out_table = OutTable::new(meta);
-
         meta.lookup(|meta| {
             let s_table = meta.query_selector(s_table);
-            let s_correct_out = meta.query_advice(s_correct_out, Rotation::cur());
+            let s_in_trace_next = meta.query_advice(s_in_trace, Rotation::next());
+            let s_in_trace = meta.query_advice(s_in_trace, Rotation::cur());
             let opcode = meta.query_advice(opcode, Rotation::cur());
             let Out {
                 and,
@@ -51,6 +52,7 @@ impl CorrectOutConfig {
             } = out.map(|c| meta.query_advice(c, Rotation::cur()));
 
             [
+                (s_in_trace_next, out_table.continue_trace),
                 // For an explanation of `opcode + 1` the comment on `OutTable`.
                 (opcode + Expression::Constant(F::one()), out_table.opcode),
                 (and, out_table.out.and),
@@ -67,7 +69,7 @@ impl CorrectOutConfig {
                 (flag3, out_table.out.flag3),
                 (flag4, out_table.out.flag4),
             ]
-            .map(|(e, t)| (s_table.clone() * s_correct_out.clone() * e, t))
+            .map(|(e, t)| (s_table.clone() * s_in_trace.clone() * e, t))
             .to_vec()
         });
 
@@ -86,6 +88,8 @@ impl CorrectOutConfig {
 pub struct OutTable {
     opcode: TableColumn,
     out: Out<TableColumn>,
+    // 0 for Answer 1 for everything else.
+    continue_trace: TableColumn,
 }
 
 impl OutTable {
@@ -93,6 +97,7 @@ impl OutTable {
         OutTable {
             opcode: meta.lookup_table_column(),
             out: Out::new(|| meta.lookup_table_column()),
+            continue_trace: meta.lookup_table_column(),
         }
     }
 
@@ -102,6 +107,7 @@ impl OutTable {
         offset: usize,
         opcode: u64,
         out: Out<bool>,
+        continue_trace: bool,
     ) {
         table
             .assign_cell(
@@ -111,6 +117,16 @@ impl OutTable {
                 || Value::known(F::from(opcode)),
             )
             .unwrap();
+
+        table
+            .assign_cell(
+                || "",
+                self.continue_trace,
+                offset,
+                || Value::known(F::from(continue_trace)),
+            )
+            .unwrap();
+
         self.out.push_cells(&mut (table, offset), out).unwrap();
     }
 
@@ -119,163 +135,79 @@ impl OutTable {
         layouter: &mut impl Layouter<F>,
     ) -> Result<(), Error> {
         layouter.assign_table(
-            || "even bits",
+            || "out_table",
             |mut table| {
-                self.assign_row(
-                    &mut table,
-                    0,
-                    And::<(), ()>::OP_CODE + 1,
-                    And::<(), ()>::OUT,
-                );
-                self.assign_row(
-                    &mut table,
-                    1,
-                    Or::<(), ()>::OP_CODE + 1,
-                    Or::<(), ()>::OUT,
-                );
-                self.assign_row(
-                    &mut table,
-                    2,
-                    Xor::<(), ()>::OP_CODE + 1,
-                    Xor::<(), ()>::OUT,
-                );
-                self.assign_row(
-                    &mut table,
-                    3,
-                    Not::<(), ()>::OP_CODE + 1,
-                    Not::<(), ()>::OUT,
-                );
-                self.assign_row(
-                    &mut table,
-                    4,
-                    Add::<(), ()>::OP_CODE + 1,
-                    Add::<(), ()>::OUT,
-                );
-                self.assign_row(
-                    &mut table,
-                    5,
-                    Sub::<(), ()>::OP_CODE + 1,
-                    Sub::<(), ()>::OUT,
-                );
-                self.assign_row(
-                    &mut table,
-                    6,
-                    Mull::<(), ()>::OP_CODE + 1,
-                    Mull::<(), ()>::OUT,
-                );
-                self.assign_row(
-                    &mut table,
-                    7,
-                    UMulh::<(), ()>::OP_CODE + 1,
-                    UMulh::<(), ()>::OUT,
-                );
-                self.assign_row(
-                    &mut table,
-                    8,
-                    SMulh::<(), ()>::OP_CODE + 1,
-                    SMulh::<(), ()>::OUT,
-                );
-                self.assign_row(
-                    &mut table,
-                    9,
-                    UDiv::<(), ()>::OP_CODE + 1,
-                    UDiv::<(), ()>::OUT,
-                );
-                self.assign_row(
-                    &mut table,
-                    10,
-                    UMod::<(), ()>::OP_CODE + 1,
-                    UMod::<(), ()>::OUT,
-                );
-                self.assign_row(
-                    &mut table,
-                    11,
-                    Shl::<(), ()>::OP_CODE + 1,
-                    Shl::<(), ()>::OUT,
-                );
-                self.assign_row(
-                    &mut table,
-                    12,
-                    Shr::<(), ()>::OP_CODE + 1,
-                    Shr::<(), ()>::OUT,
-                );
-                self.assign_row(
-                    &mut table,
-                    13,
-                    Cmpe::<(), ()>::OP_CODE + 1,
-                    Cmpe::<(), ()>::OUT,
-                );
-                self.assign_row(
-                    &mut table,
-                    14,
-                    Cmpa::<(), ()>::OP_CODE + 1,
-                    Cmpa::<(), ()>::OUT,
-                );
+                self.assign_row(&mut table, 0, And::OP_CODE + 1, And::OUT, true);
+                self.assign_row(&mut table, 1, Or::OP_CODE + 1, Or::OUT, true);
+                self.assign_row(&mut table, 2, Xor::OP_CODE + 1, Xor::OUT, true);
+                self.assign_row(&mut table, 3, Not::OP_CODE + 1, Not::OUT, true);
+                self.assign_row(&mut table, 4, Add::OP_CODE + 1, Add::OUT, true);
+                self.assign_row(&mut table, 5, Sub::OP_CODE + 1, Sub::OUT, true);
+                self.assign_row(&mut table, 6, Mull::OP_CODE + 1, Mull::OUT, true);
+                self.assign_row(&mut table, 7, UMulh::OP_CODE + 1, UMulh::OUT, true);
+                self.assign_row(&mut table, 8, SMulh::OP_CODE + 1, SMulh::OUT, true);
+                self.assign_row(&mut table, 9, UDiv::OP_CODE + 1, UDiv::OUT, true);
+                self.assign_row(&mut table, 10, UMod::OP_CODE + 1, UMod::OUT, true);
+                self.assign_row(&mut table, 11, Shl::OP_CODE + 1, Shl::OUT, true);
+                self.assign_row(&mut table, 12, Shr::OP_CODE + 1, Shr::OUT, true);
+                self.assign_row(&mut table, 13, Cmpe::OP_CODE + 1, Cmpe::OUT, true);
+                self.assign_row(&mut table, 14, Cmpa::OP_CODE + 1, Cmpa::OUT, true);
                 self.assign_row(
                     &mut table,
                     15,
-                    Cmpae::<(), ()>::OP_CODE + 1,
-                    Cmpae::<(), ()>::OUT,
+                    Cmpae::OP_CODE + 1,
+                    Cmpae::OUT,
+                    true,
                 );
-                self.assign_row(
-                    &mut table,
-                    16,
-                    Cmpg::<(), ()>::OP_CODE + 1,
-                    Cmpg::<(), ()>::OUT,
-                );
+                self.assign_row(&mut table, 16, Cmpg::OP_CODE + 1, Cmpg::OUT, true);
                 self.assign_row(
                     &mut table,
                     17,
-                    Cmpge::<(), ()>::OP_CODE + 1,
-                    Cmpge::<(), ()>::OUT,
+                    Cmpge::OP_CODE + 1,
+                    Cmpge::OUT,
+                    true,
                 );
-                self.assign_row(
-                    &mut table,
-                    18,
-                    Mov::<(), ()>::OP_CODE + 1,
-                    Mov::<(), ()>::OUT,
-                );
-                self.assign_row(
-                    &mut table,
-                    19,
-                    CMov::<(), ()>::OP_CODE + 1,
-                    CMov::<(), ()>::OUT,
-                );
-                self.assign_row(
-                    &mut table,
-                    20,
-                    Jmp::<()>::OP_CODE + 1,
-                    Jmp::<()>::OUT,
-                );
-                self.assign_row(
-                    &mut table,
-                    21,
-                    CJmp::<()>::OP_CODE + 1,
-                    CJmp::<()>::OUT,
-                );
+                self.assign_row(&mut table, 18, Mov::OP_CODE + 1, Mov::OUT, true);
+                self.assign_row(&mut table, 19, CMov::OP_CODE + 1, CMov::OUT, true);
+                self.assign_row(&mut table, 20, Jmp::OP_CODE + 1, Jmp::OUT, true);
+                self.assign_row(&mut table, 21, CJmp::OP_CODE + 1, CJmp::OUT, true);
                 self.assign_row(
                     &mut table,
                     22,
-                    CnJmp::<()>::OP_CODE + 1,
-                    CnJmp::<()>::OUT,
+                    CnJmp::OP_CODE + 1,
+                    CnJmp::OUT,
+                    true,
                 );
                 self.assign_row(
                     &mut table,
                     23,
-                    StoreW::<(), ()>::OP_CODE + 1,
-                    StoreW::<(), ()>::OUT,
+                    StoreW::OP_CODE + 1,
+                    StoreW::OUT,
+                    true,
                 );
                 self.assign_row(
                     &mut table,
                     24,
-                    LoadW::<(), ()>::OP_CODE + 1,
-                    LoadW::<(), ()>::OUT,
+                    LoadW::OP_CODE + 1,
+                    LoadW::OUT,
+                    true,
                 );
                 self.assign_row(
                     &mut table,
                     25,
-                    Answer::<()>::OP_CODE + 1,
-                    Answer::<()>::OUT,
+                    Answer::OP_CODE + 1,
+                    Answer::OUT,
+                    false,
+                );
+
+                // default value
+                self.assign_row(
+                    &mut table,
+                    26,
+                    0,
+                    // Answer has a empty Out
+                    Answer::OUT,
+                    false,
                 );
                 Ok(())
             },

--- a/src/circuits/tables/aux/out_table.rs
+++ b/src/circuits/tables/aux/out_table.rs
@@ -1,8 +1,284 @@
-use halo2_proofs::plonk::TableColumn;
+use halo2_proofs::{
+    arithmetic::FieldExt,
+    circuit::{Layouter, Table, Value},
+    plonk::{
+        Advice, Column, ConstraintSystem, Error, Expression, Selector, TableColumn,
+    },
+    poly::Rotation,
+};
 
-use super::out::Out;
+use super::out::{Out, OutPut};
+use crate::instructions::{opcode::OpCode, *};
 
+#[derive(Debug, Clone, Copy)]
+pub struct CorrectOutConfig {
+    opcode: Column<Advice>,
+    out: Out<Column<Advice>>,
+    out_table: OutTable,
+}
+
+impl CorrectOutConfig {
+    /// configure a lookup between opcode, and Out selection vector.
+    pub fn configure<F: FieldExt>(
+        meta: &mut ConstraintSystem<F>,
+        opcode: Column<Advice>,
+        out: Out<Column<Advice>>,
+        // A advice selector denoting if a line of Exe is part of the trace.
+        s_correct_out: Column<Advice>,
+        // A complex selector denoting the extent in rows of the table to decompose.
+        s_table: Selector,
+    ) -> Self {
+        let out_table = OutTable::new(meta);
+
+        meta.lookup(|meta| {
+            let s_table = meta.query_selector(s_table);
+            let s_correct_out = meta.query_advice(s_correct_out, Rotation::cur());
+            let opcode = meta.query_advice(opcode, Rotation::cur());
+            let Out {
+                and,
+                xor,
+                or,
+                sum,
+                ssum,
+                prod,
+                sprod,
+                mod_,
+                shift,
+                flag1,
+                flag2,
+                flag3,
+                flag4,
+            } = out.map(|c| meta.query_advice(c, Rotation::cur()));
+
+            [
+                // For an explanation of `opcode + 1` the comment on `OutTable`.
+                (opcode + Expression::Constant(F::one()), out_table.opcode),
+                (and, out_table.out.and),
+                (xor, out_table.out.xor),
+                (or, out_table.out.or),
+                (sum, out_table.out.sum),
+                (ssum, out_table.out.ssum),
+                (prod, out_table.out.prod),
+                (sprod, out_table.out.sprod),
+                (mod_, out_table.out.mod_),
+                (shift, out_table.out.shift),
+                (flag1, out_table.out.flag1),
+                (flag2, out_table.out.flag2),
+                (flag3, out_table.out.flag3),
+                (flag4, out_table.out.flag4),
+            ]
+            .map(|(e, t)| (s_table.clone() * s_correct_out.clone() * e, t))
+            .to_vec()
+        });
+
+        Self {
+            opcode,
+            out,
+            out_table,
+        }
+    }
+}
+
+/// The table maps `opcode + 1` to the opcode's `Out` selection vector.
+/// `opcode + 1` is used to give a default mapping `(opcode * 0, Out * 0)`.
+/// This increment is hidden from the user in the `configure` method.
+#[derive(Debug, Clone, Copy)]
 pub struct OutTable {
     opcode: TableColumn,
     out: Out<TableColumn>,
+}
+
+impl OutTable {
+    pub fn new<F: FieldExt>(meta: &mut ConstraintSystem<F>) -> Self {
+        OutTable {
+            opcode: meta.lookup_table_column(),
+            out: Out::new(|| meta.lookup_table_column()),
+        }
+    }
+
+    fn assign_row<F: FieldExt>(
+        &self,
+        table: &mut Table<'_, F>,
+        offset: usize,
+        opcode: u64,
+        out: Out<bool>,
+    ) {
+        table
+            .assign_cell(
+                || "",
+                self.opcode,
+                offset,
+                || Value::known(F::from(opcode)),
+            )
+            .unwrap();
+        self.out.push_cells(&mut (table, offset), out).unwrap();
+    }
+
+    pub fn alloc_table<F: FieldExt>(
+        self,
+        layouter: &mut impl Layouter<F>,
+    ) -> Result<(), Error> {
+        layouter.assign_table(
+            || "even bits",
+            |mut table| {
+                self.assign_row(
+                    &mut table,
+                    0,
+                    And::<(), ()>::OP_CODE + 1,
+                    And::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    1,
+                    Or::<(), ()>::OP_CODE + 1,
+                    Or::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    2,
+                    Xor::<(), ()>::OP_CODE + 1,
+                    Xor::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    3,
+                    Not::<(), ()>::OP_CODE + 1,
+                    Not::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    4,
+                    Add::<(), ()>::OP_CODE + 1,
+                    Add::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    5,
+                    Sub::<(), ()>::OP_CODE + 1,
+                    Sub::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    6,
+                    Mull::<(), ()>::OP_CODE + 1,
+                    Mull::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    7,
+                    UMulh::<(), ()>::OP_CODE + 1,
+                    UMulh::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    8,
+                    SMulh::<(), ()>::OP_CODE + 1,
+                    SMulh::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    9,
+                    UDiv::<(), ()>::OP_CODE + 1,
+                    UDiv::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    10,
+                    UMod::<(), ()>::OP_CODE + 1,
+                    UMod::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    11,
+                    Shl::<(), ()>::OP_CODE + 1,
+                    Shl::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    12,
+                    Shr::<(), ()>::OP_CODE + 1,
+                    Shr::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    13,
+                    Cmpe::<(), ()>::OP_CODE + 1,
+                    Cmpe::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    14,
+                    Cmpa::<(), ()>::OP_CODE + 1,
+                    Cmpa::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    15,
+                    Cmpae::<(), ()>::OP_CODE + 1,
+                    Cmpae::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    16,
+                    Cmpg::<(), ()>::OP_CODE + 1,
+                    Cmpg::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    17,
+                    Cmpge::<(), ()>::OP_CODE + 1,
+                    Cmpge::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    18,
+                    Mov::<(), ()>::OP_CODE + 1,
+                    Mov::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    19,
+                    CMov::<(), ()>::OP_CODE + 1,
+                    CMov::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    20,
+                    Jmp::<()>::OP_CODE + 1,
+                    Jmp::<()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    21,
+                    CJmp::<()>::OP_CODE + 1,
+                    CJmp::<()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    22,
+                    CnJmp::<()>::OP_CODE + 1,
+                    CnJmp::<()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    23,
+                    StoreW::<(), ()>::OP_CODE + 1,
+                    StoreW::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    24,
+                    LoadW::<(), ()>::OP_CODE + 1,
+                    LoadW::<(), ()>::OUT,
+                );
+                self.assign_row(
+                    &mut table,
+                    25,
+                    Answer::<()>::OP_CODE + 1,
+                    Answer::<()>::OUT,
+                );
+                Ok(())
+            },
+        )
+    }
 }

--- a/src/circuits/tables/exe.rs
+++ b/src/circuits/tables/exe.rs
@@ -18,8 +18,9 @@ use crate::{
         flag4::Flag4Config, logic::LogicConfig, modulo::ModConfig, prod::ProdConfig,
         shift::ShiftConfig, sprod::SProdConfig, ssum::SSumConfig, sum::SumConfig,
     },
+    instructions::{Instruction, Shl, Shr},
     leak_once,
-    trace::{Instruction, RegName, Registers, Shl, Shr, Trace},
+    trace::{RegName, Registers, Trace},
 };
 
 use self::temp_vars::TempVars;
@@ -993,8 +994,8 @@ mod tests {
     use proptest::{prop_compose, proptest};
 
     use crate::{
-        circuits::tables::exe::ExeCircuit, test_utils::gen_proofs_and_verify,
-        trace::*,
+        circuits::tables::exe::ExeCircuit, instructions::*,
+        test_utils::gen_proofs_and_verify, trace::*,
     };
 
     fn load_and_answer<const WORD_BITS: u32, const REG_COUNT: usize>(
@@ -1021,7 +1022,7 @@ mod tests {
         trace
     }
     fn mov_ins_answer<const WORD_BITS: u32, const REG_COUNT: usize>(
-        ins: Instruction,
+        ins: Instruction<RegName, ImmediateOrRegName>,
         b: u32,
     ) -> Trace<WORD_BITS, REG_COUNT> {
         let prog = Program(vec![

--- a/src/circuits/tables/exe/temp_vars.rs
+++ b/src/circuits/tables/exe/temp_vars.rs
@@ -7,7 +7,7 @@ use halo2_proofs::{
 use crate::{
     assign::ConstraintSys,
     circuits::tables::{
-        aux::{Out, TempVarSelectors},
+        aux::{out::Out, TempVarSelectors},
         even_bits::{EvenBitsConfig, EvenBitsTable},
     },
 };

--- a/src/circuits/tables/prog.rs
+++ b/src/circuits/tables/prog.rs
@@ -208,6 +208,7 @@ mod tests {
 
     use crate::{
         circuits::tables::prog::{ProgChip, ProgCircuit},
+        instructions::*,
         trace::*,
     };
 

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -1,0 +1,446 @@
+use std::fmt::Display;
+
+use crate::trace::{truncate, ImmediateOrRegName, RegName, Word};
+
+pub mod opcode;
+
+/// Docs for a variant are on each variant's struct,
+/// They can also be found on page 9 of the TinyRAM Architecture Specification v2.000.
+#[derive(Debug, Clone, Copy)]
+pub enum Instruction<R, A> {
+    And(And<R, A>),
+    Or(Or<R, A>),
+    Xor(Xor<R, A>),
+    Not(Not<R, A>),
+    Add(Add<R, A>),
+    Sub(Sub<R, A>),
+    Mull(Mull<R, A>),
+    UMulh(UMulh<R, A>),
+    SMulh(SMulh<R, A>),
+    UDiv(UDiv<R, A>),
+    UMod(UMod<R, A>),
+    Shl(Shl<R, A>),
+    Shr(Shr<R, A>),
+    /// compare equal
+    Cmpe(Cmpe<R, A>),
+    /// compare above, unsigned
+    Cmpa(Cmpa<R, A>),
+    /// compare above or equal, unsigned
+    Cmpae(Cmpae<R, A>),
+    // compare greater signed
+    Cmpg(Cmpg<R, A>),
+    /// compare greater or equal, signed
+    Cmpge(Cmpge<R, A>),
+    Mov(Mov<R, A>),
+    CMov(CMov<R, A>),
+    Jmp(Jmp<A>),
+    CJmp(CJmp<A>),
+    CnJmp(CnJmp<A>),
+    StoreW(StoreW<R, A>),
+    LoadW(LoadW<R, A>),
+    Answer(Answer<A>),
+}
+
+impl<R, A> Instruction<R, A> {
+    pub fn name(&self) -> &str {
+        match self {
+            Instruction::And(_) => "And",
+            Instruction::LoadW(_) => "Load.w",
+            Instruction::StoreW(_) => "Store.w",
+            Instruction::Answer(_) => "Answer",
+            Instruction::Or(_) => "Or",
+            Instruction::Xor(_) => "Xor",
+            Instruction::Not(_) => "Not",
+            Instruction::Add(_) => "Add",
+            Instruction::Sub(_) => "Sub",
+            Instruction::Mull(_) => "Mull",
+            Instruction::UMulh(_) => "UMulh",
+            Instruction::SMulh(_) => "SMulh",
+            Instruction::UDiv(_) => "Udiv",
+            Instruction::UMod(_) => "UMod",
+            Instruction::Shl(_) => "Shl",
+            Instruction::Shr(_) => "Shr",
+            Instruction::Cmpe(_) => "Cmpe",
+            Instruction::Cmpa(_) => "Cmpa",
+            Instruction::Cmpae(_) => "Cmpae",
+            Instruction::Cmpg(_) => "Cmpg",
+            Instruction::Cmpge(_) => "Cmpge",
+            Instruction::Mov(_) => "Mov",
+            Instruction::CMov(_) => "Cmov",
+            Instruction::Jmp(_) => "Jmp",
+            Instruction::CJmp(_) => "CJmp",
+            Instruction::CnJmp(_) => "CnJmp",
+        }
+    }
+
+    /// See TinyRAM 2.0 spec (page 16)
+    /// The op code is the first field (`#1` in the table) of the binary instruction encoding.
+    pub fn opcode(&self) -> u128 {
+        match self {
+            Instruction::And(_) => 0b00000,
+            Instruction::Or(_) => 0b00001,
+            Instruction::Xor(_) => 0b00010,
+            Instruction::Not(_) => 0b00011,
+            Instruction::Add(_) => 0b00100,
+            Instruction::Sub(_) => 0b00101,
+            Instruction::Mull(_) => 0b00110,
+            Instruction::UMulh(_) => 0b00111,
+            Instruction::SMulh(_) => 0b01000,
+            Instruction::UDiv(_) => 0b01001,
+            Instruction::UMod(_) => 0b01010,
+            Instruction::Shl(_) => 0b01011,
+            Instruction::Shr(_) => 0b01100,
+            Instruction::Cmpe(_) => 0b01101,
+            Instruction::Cmpa(_) => 0b01110,
+            Instruction::Cmpae(_) => 0b01111,
+            Instruction::Cmpg(_) => 0b10000,
+            Instruction::Cmpge(_) => 0b10001,
+            Instruction::Mov(_) => 0b10010,
+            Instruction::CMov(_) => 0b10011,
+            Instruction::Jmp(_) => 0b10100,
+            Instruction::CJmp(_) => 0b10101,
+            Instruction::CnJmp(_) => 0b10110,
+            Instruction::StoreW(_) => 0b11100,
+            Instruction::LoadW(_) => 0b11101,
+            Instruction::Answer(_) => 0b11111,
+        }
+    }
+
+    pub fn is_store(&self) -> bool {
+        matches!(self, Instruction::StoreW(_))
+    }
+
+    pub fn is_load(&self) -> bool {
+        matches!(self, Instruction::LoadW(_))
+    }
+}
+
+impl Instruction<RegName, ImmediateOrRegName> {
+    pub fn ri(&self) -> Option<RegName> {
+        match self {
+            Instruction::And(And { ri, .. })
+            | Instruction::LoadW(LoadW { ri, .. })
+            | Instruction::StoreW(StoreW { ri, .. })
+            | Instruction::Or(Or { ri, .. })
+            | Instruction::Xor(Xor { ri, .. })
+            | Instruction::Not(Not { ri, .. })
+            | Instruction::Add(Add { ri, .. })
+            | Instruction::Sub(Sub { ri, .. })
+            | Instruction::Mull(Mull { ri, .. })
+            | Instruction::UMulh(UMulh { ri, .. })
+            | Instruction::SMulh(SMulh { ri, .. })
+            | Instruction::UDiv(UDiv { ri, .. })
+            | Instruction::UMod(UMod { ri, .. })
+            | Instruction::Shl(Shl { ri, .. })
+            | Instruction::Shr(Shr { ri, .. })
+            | Instruction::Cmpe(Cmpe { ri, .. })
+            | Instruction::Cmpa(Cmpa { ri, .. })
+            | Instruction::Cmpae(Cmpae { ri, .. })
+            | Instruction::Cmpg(Cmpg { ri, .. })
+            | Instruction::Cmpge(Cmpge { ri, .. })
+            | Instruction::Mov(Mov { ri, .. })
+            | Instruction::CMov(CMov { ri, .. }) => Some(*ri),
+            Instruction::Answer(_)
+            | Instruction::Jmp(_)
+            | Instruction::CJmp(_)
+            | Instruction::CnJmp(_) => None,
+        }
+    }
+
+    pub fn rj(&self) -> Option<RegName> {
+        match self {
+            Instruction::And(And { rj, .. })
+            | Instruction::Or(Or { rj, .. })
+            | Instruction::Xor(Xor { rj, .. })
+            | Instruction::Add(Add { rj, .. })
+            | Instruction::Sub(Sub { rj, .. })
+            | Instruction::Mull(Mull { rj, .. })
+            | Instruction::UMulh(UMulh { rj, .. })
+            | Instruction::SMulh(SMulh { rj, .. })
+            | Instruction::UDiv(UDiv { rj, .. })
+            | Instruction::UMod(UMod { rj, .. })
+            | Instruction::Shl(Shl { rj, .. })
+            | Instruction::Shr(Shr { rj, .. }) => Some(*rj),
+            Instruction::Answer(_)
+            | Instruction::Cmpe(_)
+            | Instruction::Cmpa(_)
+            | Instruction::Cmpae(_)
+            | Instruction::Cmpg(_)
+            | Instruction::Cmpge(_)
+            | Instruction::Mov(_)
+            | Instruction::CMov(_)
+            | Instruction::Jmp(_)
+            | Instruction::CJmp(_)
+            | Instruction::CnJmp(_)
+            | Instruction::Not(_)
+            | Instruction::StoreW(_)
+            | Instruction::LoadW(_) => None,
+        }
+    }
+
+    pub fn a(&self) -> ImmediateOrRegName {
+        match self {
+            Instruction::And(And { a, .. })
+            | Instruction::LoadW(LoadW { a, .. })
+            | Instruction::StoreW(StoreW { a, .. })
+            | Instruction::Or(Or { a, .. })
+            | Instruction::Xor(Xor { a, .. })
+            | Instruction::Not(Not { a, .. })
+            | Instruction::Add(Add { a, .. })
+            | Instruction::Sub(Sub { a, .. })
+            | Instruction::Mull(Mull { a, .. })
+            | Instruction::UMulh(UMulh { a, .. })
+            | Instruction::SMulh(SMulh { a, .. })
+            | Instruction::UDiv(UDiv { a, .. })
+            | Instruction::UMod(UMod { a, .. })
+            | Instruction::Shl(Shl { a, .. })
+            | Instruction::Shr(Shr { a, .. })
+            | Instruction::Cmpe(Cmpe { a, .. })
+            | Instruction::Cmpa(Cmpa { a, .. })
+            | Instruction::Cmpae(Cmpae { a, .. })
+            | Instruction::Cmpg(Cmpg { a, .. })
+            | Instruction::Cmpge(Cmpge { a, .. })
+            | Instruction::Mov(Mov { a, .. })
+            | Instruction::CMov(CMov { a, .. })
+            | Instruction::Jmp(Jmp { a, .. })
+            | Instruction::CJmp(CJmp { a, .. })
+            | Instruction::CnJmp(CnJmp { a, .. })
+            | Instruction::Answer(Answer { a }) => *a,
+        }
+    }
+}
+
+impl Display for Instruction<RegName, ImmediateOrRegName> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} ", self.name())?;
+        match self {
+            Instruction::And(And { ri, rj, a })
+            | Instruction::Or(Or { ri, rj, a })
+            | Instruction::Xor(Xor { ri, rj, a })
+            | Instruction::Add(Add { ri, rj, a })
+            | Instruction::Sub(Sub { ri, rj, a })
+            | Instruction::Mull(Mull { ri, rj, a })
+            | Instruction::UMulh(UMulh { ri, rj, a })
+            | Instruction::SMulh(SMulh { ri, rj, a })
+            | Instruction::UDiv(UDiv { ri, rj, a })
+            | Instruction::UMod(UMod { ri, rj, a })
+            | Instruction::Shl(Shl { ri, rj, a })
+            | Instruction::Shr(Shr { ri, rj, a }) => {
+                write!(f, "r{} ", ri.0)?;
+                write!(f, "r{} ", rj.0)?;
+                write!(f, "{}", a)
+            }
+            Instruction::Not(Not { ri, a })
+            | Instruction::Cmpe(Cmpe { ri, a })
+            | Instruction::Cmpa(Cmpa { ri, a })
+            | Instruction::Cmpae(Cmpae { ri, a })
+            | Instruction::Cmpg(Cmpg { ri, a })
+            | Instruction::Cmpge(Cmpge { ri, a })
+            | Instruction::Mov(Mov { ri, a })
+            | Instruction::CMov(CMov { ri, a })
+            | Instruction::LoadW(LoadW { ri, a })
+            | Instruction::StoreW(StoreW { ri, a }) => {
+                write!(f, "r{} ", ri.0)?;
+                write!(f, "{}", a)
+            }
+
+            Instruction::Jmp(Jmp { a })
+            | Instruction::CJmp(CJmp { a })
+            | Instruction::CnJmp(CnJmp { a })
+            | Instruction::Answer(Answer { a }) => write!(f, "{}", a),
+        }
+    }
+}
+
+/// compute bitwise AND of `[rj]` and `[A]` and store result in ri
+#[derive(Debug, Clone, Copy)]
+pub struct And<R, A> {
+    pub ri: R,
+    pub rj: R,
+    pub a: A,
+}
+
+/// compute bitwise OR of `[rj]` and `[A]` and store result in ri
+#[derive(Debug, Clone, Copy)]
+pub struct Or<R, A> {
+    pub ri: R,
+    pub rj: R,
+    pub a: A,
+}
+
+/// compute bitwise OR of `[rj]` and `[A]` and store result in ri
+#[derive(Debug, Clone, Copy)]
+pub struct Xor<R, A> {
+    pub ri: R,
+    pub rj: R,
+    pub a: A,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Not<R, A> {
+    pub ri: R,
+    pub a: A,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Add<R, A> {
+    pub ri: R,
+    pub rj: R,
+    pub a: A,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Sub<R, A> {
+    pub ri: R,
+    pub rj: R,
+    pub a: A,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Mull<R, A> {
+    pub ri: R,
+    pub rj: R,
+    pub a: A,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct UMulh<R, A> {
+    pub ri: R,
+    pub rj: R,
+    pub a: A,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SMulh<R, A> {
+    pub ri: R,
+    pub rj: R,
+    pub a: A,
+}
+
+impl SMulh<RegName, ImmediateOrRegName> {
+    /// Returns the `(upper bits, lower bits, flag)` of signed multiplication.
+    /// The flag is set if `a * b` is out of range of the word size.
+    pub fn eval<const WORD_BITS: u32>(a: Word, b: Word) -> (Word, Word, bool) {
+        let a = a.into_signed(WORD_BITS) as i128;
+        let b = b.into_signed(WORD_BITS) as i128;
+
+        let f = a * b;
+
+        let lower = truncate::<WORD_BITS>(f as u128);
+        let upper = truncate::<WORD_BITS>((f >> WORD_BITS) as u128);
+
+        let m = 2i128.pow(WORD_BITS - 1);
+        let flag = f >= m || f < -m;
+
+        assert_eq!(f.is_negative(), upper.into_signed(WORD_BITS).is_negative());
+        (upper, lower, flag)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct UDiv<R, A> {
+    pub ri: R,
+    pub rj: R,
+    pub a: A,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct UMod<R, A> {
+    pub ri: R,
+    pub rj: R,
+    pub a: A,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Shl<R, A> {
+    pub ri: R,
+    pub rj: R,
+    pub a: A,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Shr<R, A> {
+    pub ri: R,
+    pub rj: R,
+    pub a: A,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Cmpe<R, A> {
+    pub ri: R,
+    pub a: A,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Cmpa<R, A> {
+    pub ri: R,
+    pub a: A,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Cmpae<R, A> {
+    pub ri: R,
+    pub a: A,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Cmpg<R, A> {
+    pub ri: R,
+    pub a: A,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Cmpge<R, A> {
+    pub ri: R,
+    pub a: A,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Mov<R, A> {
+    pub ri: R,
+    pub a: A,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct CMov<R, A> {
+    pub ri: R,
+    pub a: A,
+}
+
+/// stall or halt (and the return value is `[A]u` )
+#[derive(Debug, Clone, Copy)]
+pub struct Jmp<A> {
+    pub a: A,
+}
+
+/// stall or halt (and the return value is `[A]u` )
+#[derive(Debug, Clone, Copy)]
+pub struct CJmp<A> {
+    pub a: A,
+}
+
+/// stall or halt (and the return value is `[A]u` )
+#[derive(Debug, Clone, Copy)]
+pub struct CnJmp<A> {
+    pub a: A,
+}
+
+/// Store into ri the word in memory that is aligned to the `[A]w-th` byte.
+#[derive(Debug, Clone, Copy)]
+pub struct LoadW<R, A> {
+    pub ri: R,
+    pub a: A,
+}
+
+/// store `[ri]` at the word in memory that is aligned to the `[A]w-th` byte
+#[derive(Debug, Clone, Copy)]
+pub struct StoreW<R, A> {
+    pub ri: R,
+    pub a: A,
+}
+
+/// stall or halt (and the return value is `[A]u` )
+#[derive(Debug, Clone, Copy)]
+pub struct Answer<A> {
+    pub a: A,
+}

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -444,3 +444,59 @@ pub struct StoreW<R, A> {
 pub struct Answer<A> {
     pub a: A,
 }
+
+/// Conveniance aliases for Instructions type with unit type Arguments.
+pub mod unit {
+
+    pub type And = super::And<(), ()>;
+
+    pub type Or = super::Or<(), ()>;
+
+    pub type Xor = super::Xor<(), ()>;
+
+    pub type Not = super::Not<(), ()>;
+
+    pub type Add = super::Add<(), ()>;
+
+    pub type Sub = super::Sub<(), ()>;
+
+    pub type Mull = super::Mull<(), ()>;
+
+    pub type UMulh = super::UMulh<(), ()>;
+
+    pub type SMulh = super::SMulh<(), ()>;
+
+    pub type UDiv = super::UDiv<(), ()>;
+
+    pub type UMod = super::UMod<(), ()>;
+
+    pub type Shl = super::Shl<(), ()>;
+
+    pub type Shr = super::Shr<(), ()>;
+
+    pub type Cmpe = super::Cmpe<(), ()>;
+
+    pub type Cmpa = super::Cmpa<(), ()>;
+
+    pub type Cmpae = super::Cmpae<(), ()>;
+
+    pub type Cmpg = super::Cmpg<(), ()>;
+
+    pub type Cmpge = super::Cmpge<(), ()>;
+
+    pub type Mov = super::Mov<(), ()>;
+
+    pub type CMov = super::CMov<(), ()>;
+
+    pub type Jmp = super::Jmp<()>;
+
+    pub type CJmp = super::CJmp<()>;
+
+    pub type CnJmp = super::CnJmp<()>;
+
+    pub type LoadW = super::LoadW<(), ()>;
+
+    pub type StoreW = super::StoreW<(), ()>;
+
+    pub type Answer = super::Answer<()>;
+}

--- a/src/instructions/opcode.rs
+++ b/src/instructions/opcode.rs
@@ -1,0 +1,84 @@
+use super::*;
+
+pub trait OpCode {
+    const OP_CODE: u64;
+}
+
+impl<R, A> OpCode for And<R, A> {
+    const OP_CODE: u64 = 0b00000;
+}
+impl<R, A> OpCode for Or<R, A> {
+    const OP_CODE: u64 = 0b00001;
+}
+impl<R, A> OpCode for Xor<R, A> {
+    const OP_CODE: u64 = 0b00010;
+}
+impl<R, A> OpCode for Not<R, A> {
+    const OP_CODE: u64 = 0b00011;
+}
+impl<R, A> OpCode for Add<R, A> {
+    const OP_CODE: u64 = 0b00100;
+}
+impl<R, A> OpCode for Sub<R, A> {
+    const OP_CODE: u64 = 0b00101;
+}
+impl<R, A> OpCode for Mull<R, A> {
+    const OP_CODE: u64 = 0b00110;
+}
+impl<R, A> OpCode for UMulh<R, A> {
+    const OP_CODE: u64 = 0b00111;
+}
+impl<R, A> OpCode for SMulh<R, A> {
+    const OP_CODE: u64 = 0b01000;
+}
+impl<R, A> OpCode for UDiv<R, A> {
+    const OP_CODE: u64 = 0b01001;
+}
+impl<R, A> OpCode for UMod<R, A> {
+    const OP_CODE: u64 = 0b01010;
+}
+impl<R, A> OpCode for Shl<R, A> {
+    const OP_CODE: u64 = 0b01011;
+}
+impl<R, A> OpCode for Shr<R, A> {
+    const OP_CODE: u64 = 0b01100;
+}
+impl<R, A> OpCode for Cmpe<R, A> {
+    const OP_CODE: u64 = 0b01101;
+}
+impl<R, A> OpCode for Cmpa<R, A> {
+    const OP_CODE: u64 = 0b01110;
+}
+impl<R, A> OpCode for Cmpae<R, A> {
+    const OP_CODE: u64 = 0b01111;
+}
+impl<R, A> OpCode for Cmpg<R, A> {
+    const OP_CODE: u64 = 0b10000;
+}
+impl<R, A> OpCode for Cmpge<R, A> {
+    const OP_CODE: u64 = 0b10001;
+}
+impl<R, A> OpCode for Mov<R, A> {
+    const OP_CODE: u64 = 0b10010;
+}
+impl<R, A> OpCode for CMov<R, A> {
+    const OP_CODE: u64 = 0b10011;
+}
+impl<A> OpCode for Jmp<A> {
+    const OP_CODE: u64 = 0b10100;
+}
+impl<A> OpCode for CJmp<A> {
+    const OP_CODE: u64 = 0b10101;
+}
+impl<A> OpCode for CnJmp<A> {
+    const OP_CODE: u64 = 0b10110;
+}
+impl<R, A> OpCode for StoreW<R, A> {
+    const OP_CODE: u64 = 0b11100;
+}
+impl<R, A> OpCode for LoadW<R, A> {
+    const OP_CODE: u64 = 0b11101;
+}
+impl<A> OpCode for Answer<A> {
+    const OP_CODE: u64 = 0b11111;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod assign;
 pub mod circuits;
+pub mod instructions;
 #[cfg(test)]
 pub mod test_utils;
 pub mod trace;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -17,7 +17,7 @@ pub fn gen_proofs_and_verify<
     };
     use rand_core::OsRng;
 
-    let k = 1 + WORD_BITS / 2;
+    let k = 2 + WORD_BITS / 2;
     let params: Params<EqAffine> = halo2_proofs::poly::commitment::Params::new(k);
     let empty_circuit = C::default();
     let vk = keygen_vk(&params, &empty_circuit).unwrap();


### PR DESCRIPTION
1. Enforce that the Out selection vector matches the instruction.
2. Introduce `in_trace` an advice selector that denotes the extent of the trace in the Exe table.
3. Now that we have `in_trace` `time` can be a fixed column.